### PR TITLE
Renamed ARM CI; renamed macOS packages; added ARM CI badge to README

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         git clone https://github.com/dbouget/quickpkg.git
         quickpkg/quickpkg dist/Raidionics.app --output Raidionics-1.2.1-macOS.pkg
-        cp -r Raidionics-1.2.1-macOS.pkg dist/Raidionics-1.2.1-macOS.pkg
+        cp -r Raidionics-1.2.1-macOS.pkg dist/Raidionics-1.2.1-macOS-x86_64.pkg
 
     - name: Upload package
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build_macos_arm.yml
+++ b/.github/workflows/build_macos_arm.yml
@@ -1,4 +1,4 @@
-name: Build macOS M1
+name: Build macOS ARM
 
 on:
   # Allows to run the workflow manually from the Actions tab
@@ -80,7 +80,7 @@ jobs:
       run: |
         git clone https://github.com/dbouget/quickpkg.git
         quickpkg/quickpkg dist/Raidionics.app --output Raidionics-1.2.1-macOS.pkg
-        cp -r Raidionics-1.2.1-macOS.pkg dist/Raidionics-1.2.1-macOS.pkg
+        cp -r Raidionics-1.2.1-macOS.pkg dist/Raidionics-1.2.1-macOS-arm64.pkg
 
     - name: Upload package
       uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Very simple demonstrations of the software can be found on [Youtube](https://www
 | - | - |
 | **Windows** | ![CI](https://github.com/AICAN-Research/FAST-Pathology/workflows/Build%20Windows/badge.svg?branch=master&event=push) |
 | **Ubuntu** | ![CI](https://github.com/AICAN-Research/FAST-Pathology/workflows/Build%20Ubuntu/badge.svg?branch=master&event=push) |
-| **macOS** | ![CI](https://github.com/AICAN-Research/FAST-Pathology/workflows/Build%20macOS/badge.svg?branch=master&event=push) |
+| **macOS_x86-64** | ![CI](https://github.com/AICAN-Research/FAST-Pathology/workflows/Build%20macOS/badge.svg?branch=master&event=push) |
+| **macOS_ARM** | ![CI](https://github.com/AICAN-Research/FAST-Pathology/workflows/Build%20macOS%20ARM/badge.svg?branch=master&event=push) |
 
 ## [How to cite](https://github.com/raidionics/Raidionics#how-to-cite)
 If you are using Raidionics in your research, please cite the following references.


### PR DESCRIPTION
Used similar naming convention as in [smistad/FAST](https://github.com/smistad/FAST/releases/tag/v4.7.1).