### PR TITLE
Added simple GUI launch test to CIs

### DIFF
--- a/.github/workflows/build_macos.yml
+++ b/.github/workflows/build_macos.yml
@@ -50,6 +50,10 @@ jobs:
         pip install pyinstaller==5.13.2
         mkdir tmp_dependencies
         pyinstaller --log-level DEBUG --noconfirm --clean assets/main.spec
+    
+    - name: Test executable
+      run: QT_QPA_PLATFORM="offscreen" ./dist/Raidionics/Raidionics & sleep 5; kill -INT %+
+      shell: bash
 
     - name: Make installer
       run: |

--- a/.github/workflows/build_macos_arm.yml
+++ b/.github/workflows/build_macos_arm.yml
@@ -76,6 +76,10 @@ jobs:
         pip3 install pyinstaller==5.13.2
         mkdir tmp_dependencies
         pyinstaller --log-level DEBUG --noconfirm --clean assets/main_arm.spec
+    
+    - name: Test executable
+      run: QT_QPA_PLATFORM="offscreen" ./dist/Raidionics/Raidionics & sleep 5; kill -INT %+
+      shell: bash
 
     - name: Make installer
       run: |

--- a/.github/workflows/build_ubuntu.yml
+++ b/.github/workflows/build_ubuntu.yml
@@ -59,7 +59,11 @@ jobs:
         pip install pyinstaller==5.13.2
         mkdir tmp_dependencies
         pyinstaller --log-level DEBUG --noconfirm --clean assets/main.spec
-
+  
+    - name: Test executable
+      run: QT_QPA_PLATFORM="offscreen" ./dist/Raidionics/Raidionics & sleep 5; kill -INT %+
+      shell: bash
+  
     - name: Make installer
       run: |
         mkdir -p assets/Raidionics_ubuntu/usr/local/bin

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -50,6 +50,10 @@ jobs:
         pip install pyinstaller==5.13.2
         mkdir tmp_dependencies
         pyinstaller --log-level DEBUG --noconfirm --clean assets/main.spec
+      
+    - name: Test executable
+      run: QT_QPA_PLATFORM="offscreen" ./dist/Raidionics/Raidionics & sleep 5; kill -INT %+
+      shell: bash
 
     - name: Make installer
       run: |


### PR DESCRIPTION
[no ci]

This only testes that the generated exectuable launches without any errors, which may be relevant to test when changing dependencies and versions before merging PRs to the master branch.